### PR TITLE
Use Union instead of | for backwards-compatibility with Python 3.9

### DIFF
--- a/model_inference.py
+++ b/model_inference.py
@@ -4,6 +4,7 @@ import xgboost as xgb
 import numpy as np
 import tempfile
 import os
+from typing import Union
 
 # Load the saved model:
 @task
@@ -34,7 +35,7 @@ def load_model(filename: str) -> xgb.Booster:
 
 # Run inference with loaded model:
 @task
-def predict(model: xgb.Booster, X: list[list[float]] | np.ndarray) -> np.ndarray:
+def predict(model: xgb.Booster, X: Union[list[list[float]], np.ndarray]) -> np.ndarray:
     """Make predictions using the loaded model
     Args:
         model: Loaded XGBoost model
@@ -47,7 +48,7 @@ def predict(model: xgb.Booster, X: list[list[float]] | np.ndarray) -> np.ndarray
     return predictions
 
 @flow(log_prints=True)
-def run_inference(samples: list[list[float]] | None = None) -> None:
+def run_inference(samples: Union[list[list[float]], None] = None) -> None:
     samples = samples or [[5.0,3.4,1.5,0.2], [6.4,3.2,4.5,1.5], [7.2,3.6,6.1,2.5]]
     model = load_model('xgboost-model')
     predictions = predict(model, samples)

--- a/model_training.py
+++ b/model_training.py
@@ -6,7 +6,7 @@ import sagemaker
 from sagemaker.xgboost.estimator import XGBoost
 import boto3
 from sagemaker.session import Session
-from typing import TypedDict
+from typing import TypedDict, Union
 
 class TrainingInputs(TypedDict):
     train: str
@@ -71,7 +71,7 @@ def create_xgboost_estimator(sagemaker_session: Session, role_arn: str) -> XGBoo
     )
 
 @flow(log_prints=True)
-def train_model(data_bucket: str | None = None, model_bucket: str | None = None) -> XGBoost:
+def train_model(data_bucket: Union[str, None] = None, model_bucket: Union[str, None] = None) -> XGBoost:
     """Main flow to train XGBoost model on Iris dataset using SageMaker."""
     data_bucket = data_bucket or "prefect-ml-data"
     model_bucket = model_bucket or "prefect-model"


### PR DESCRIPTION
Replicates the updates to the docs in https://github.com/PrefectHQ/prefect/commit/a19131cf3f53a09b39b15dfabb55824e55d0bbb4